### PR TITLE
cicd: add top-level permissions: read-all

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,7 @@
 name: Rust CI
 
+permissions: read-all
+
 on:
   push:
     branches: [ '*', '*/*' ]


### PR DESCRIPTION
This PR adds permissions to the GitHub Actions workflow file in accordance with the CodeQL warnings.