### PR TITLE
refactor: lint by clippy

### DIFF
--- a/src/phase.rs
+++ b/src/phase.rs
@@ -27,7 +27,7 @@ pub(crate) fn u8_to_phase(phase_code: u8) -> Phase {
                 any::type_name::<Phase>(),
                 phase_code
             );
-            return Phase::Cleanup;
+            Phase::Cleanup
         }
     }
 }


### PR DESCRIPTION
This pull request refactors several sections of the `src/lock.rs` and `src/phase.rs` files to improve code clarity and idiomatic usage. The main changes involve replacing deprecated or less idiomatic Rust patterns with more standard ones, such as using `core::ptr::swap` instead of `mem::swap`, simplifying error handling, and removing unnecessary `return` statements.

Refactoring for idiomatic Rust:

* Replaced `mem::swap` with `core::ptr::swap` for swapping values in unsafe blocks within `PhasedLock<T>` methods, improving clarity and correctness. [[1]](diffhunk://#diff-9ce4c5920c454f1b2d1d0f7f48d7341aa91960831d15cfe53ce0a05dc6c1eeb5L80-R85) [[2]](diffhunk://#diff-9ce4c5920c454f1b2d1d0f7f48d7341aa91960831d15cfe53ce0a05dc6c1eeb5L158-R158)
* Simplified error handling by replacing patterns like `if let Err(_) = result` and explicit `return` statements with more idiomatic Rust expressions (`result.is_err()`, direct expression returns) in multiple methods. [[1]](diffhunk://#diff-9ce4c5920c454f1b2d1d0f7f48d7341aa91960831d15cfe53ce0a05dc6c1eeb5L287-R287) [[2]](diffhunk://#diff-9ce4c5920c454f1b2d1d0f7f48d7341aa91960831d15cfe53ce0a05dc6c1eeb5L338-R338) [[3]](diffhunk://#diff-9e8ed06efffc2fec8e4b8e149b49a834e97d7bafccb5ae62391a637baf5da829L30-R30)
* Removed unnecessary `return` statements in match arms for better readability and conciseness in error handling within `PhasedLock<T>` methods. [[1]](diffhunk://#diff-9ce4c5920c454f1b2d1d0f7f48d7341aa91960831d15cfe53ce0a05dc6c1eeb5L218-R230) [[2]](diffhunk://#diff-9e8ed06efffc2fec8e4b8e149b49a834e97d7bafccb5ae62391a637baf5da829L30-R30)

Dependency and import updates:

* Cleaned up imports by removing redundant `mem` import and relying on `core::ptr` for swap operations.