### PR TITLE
update!: changed transition_to_read not to operate mutex in fetch_update of AtomicU8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,10 @@ pub enum PhasedErrorKind {
     MutexIsPoisoned,
     /// An error indicating that a phase transition to the Read phase failed.
     TransitionToReadFailed,
+    /// An error indicating that the phase is already in the Read phase.
+    PhaseIsAlreadyRead,
+    /// An error indicating that a transition to the Read phase is currently in progress.
+    DuringTransitionToRead,
     /// An error indicating that a phase transition to the Cleanup phase timed out.
     TransitionToCleanupTimeout(WaitStrategy),
     /// An error indicating that a closure failed to run during a phase

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -90,14 +90,14 @@ impl<T: Send + Sync> PhasedLock<T> {
                         unsafe {
                             core::ptr::swap(self.data_fixed.get(), &mut *data_opt);
                         }
-
-                        let _result = self.phase.compare_exchange(
-                            PHASE_SETUP_TO_READ,
-                            PHASE_READ,
-                            atomic::Ordering::AcqRel,
-                            atomic::Ordering::Acquire,
-                        );
                     }
+
+                    let _result = self.phase.compare_exchange(
+                        PHASE_SETUP_TO_READ,
+                        PHASE_READ,
+                        atomic::Ordering::AcqRel,
+                        atomic::Ordering::Acquire,
+                    );
 
                     Ok(())
                 }

--- a/src/phase.rs
+++ b/src/phase.rs
@@ -9,6 +9,7 @@ use std::{any, fmt};
 pub(crate) const PHASE_SETUP: u8 = 0;
 pub(crate) const PHASE_READ: u8 = 1;
 pub(crate) const PHASE_CLEANUP: u8 = 2;
+pub(crate) const PHASE_SETUP_TO_READ: u8 = 3;
 
 impl fmt::Display for Phase {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -21,6 +22,7 @@ pub(crate) fn u8_to_phase(phase_code: u8) -> Phase {
         PHASE_SETUP => Phase::Setup,
         PHASE_READ => Phase::Read,
         PHASE_CLEANUP => Phase::Cleanup,
+        PHASE_SETUP_TO_READ => Phase::Setup,
         _ => {
             eprintln!(
                 "{} is passed an invalid phase code: {}",
@@ -55,6 +57,7 @@ mod tests_of_phase {
         assert_eq!(u8_to_phase(PHASE_SETUP), Phase::Setup);
         assert_eq!(u8_to_phase(PHASE_READ), Phase::Read);
         assert_eq!(u8_to_phase(PHASE_CLEANUP), Phase::Cleanup);
+        assert_eq!(u8_to_phase(PHASE_SETUP_TO_READ), Phase::Setup);
         assert_eq!(u8_to_phase(10), Phase::Cleanup);
     }
 }


### PR DESCRIPTION
This PR changes the Mutex-based internal data operation inside the `PhasedLock#transition_to_read` method so that it's no longer performed within `AtomicU8#fetch_update`. 

The primary reason for this change is that asynchronous operations cannot be executed inside `AtomicU8#fetch_update`, which is necessary for creating a tokio version of `PhasedLock`.

In order to align the implementations of the standard-thread `PhasedLock` and the tokio-thread `PhasedLock` as much as possible, this change is being made.