### PR TITLE
update!: changed feature name to: setup_read_cleanup-on-tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,11 @@ categories = ["concurrency", "asynchronous", "rust-patterns"]
 tokio = { version = "1.29", features = ["rt-multi-thread", "macros"], optional = true }
 
 [features]
+setup_read_cleanup-on-tokio = ["tokio"]
+
 default = []
 
-setup_read_cleanup-on-tokio-rt = ["tokio"]
-
-full = [
-  "setup_read_cleanup-on-tokio-rt"
-]
+full = ["setup_read_cleanup-on-tokio"]
 
 [dev-dependencies]
 once_cell = "=1.20.3"

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -12,7 +12,7 @@ use std::{any, cell, error, marker, sync, sync::atomic, thread, time};
 
 macro_rules! cannot_call_on_tokio_runtime {
     ( $plock:ident, $method:literal ) => {
-        #[cfg(feature = "setup_read_cleanup-on-tokio-rt")]
+        #[cfg(feature = "setup_read_cleanup-on-tokio")]
         {
             if tokio::runtime::Handle::try_current().is_ok() {
                 return Err(PhasedError::new(
@@ -622,7 +622,7 @@ mod tests_of_phase_lock {
         }
     }
 
-    #[cfg(feature = "setup_read_cleanup-on-tokio-rt")]
+    #[cfg(feature = "setup_read_cleanup-on-tokio")]
     mod tests_of_new_on_tokio_rt {
         use super::*;
 
@@ -736,7 +736,7 @@ mod tests_of_phase_lock {
         }
     }
 
-    #[cfg(feature = "setup_read_cleanup-on-tokio-rt")]
+    #[cfg(feature = "setup_read_cleanup-on-tokio")]
     mod tests_of_phase_transition_on_tokio_rt {
         use super::*;
 
@@ -955,7 +955,7 @@ mod tests_of_phase_lock {
         }
     }
 
-    #[cfg(feature = "setup_read_cleanup-on-tokio-rt")]
+    #[cfg(feature = "setup_read_cleanup-on-tokio")]
     mod tests_in_setup_phase_on_tokio_rt {
         use super::*;
 
@@ -1156,7 +1156,7 @@ mod tests_of_phase_lock {
         }
     }
 
-    #[cfg(feature = "setup_read_cleanup-on-tokio-rt")]
+    #[cfg(feature = "setup_read_cleanup-on-tokio")]
     mod tests_in_read_phase_on_tokio_rt {
         use super::*;
 
@@ -1517,7 +1517,7 @@ mod tests_of_phase_lock {
         }
     }
 
-    #[cfg(feature = "setup_read_cleanup-on-tokio-rt")]
+    #[cfg(feature = "setup_read_cleanup-on-tokio")]
     mod tests_in_cleanup_phase_on_tokio_rt {
         use super::*;
 


### PR DESCRIPTION
And, I am planning to add `setup_read_cleanup-on-std` later to distinguish methods and fields that will only be used on standard threads.