### PR TITLE
update!: changed PhasedCell#transition_to_cleanup method to accept a closure as an argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub enum PhasedErrorKind {
     TransitionToCleanupFailed,
     TransitionToCleanupTimeout(Wait),
     FailToRunClosureDuringTransitionToRead,
+    FailToRunClosureDuringTransitionToCleanup,
     StdMutexIsPoisoned,
 }
 


### PR DESCRIPTION
This PR modifies the `PhasedCell`'s `transition_to_cleanup` method to accept a closure as an argument.

Previously, it took an instance of a `Wait` struct as an argument to specify one of three waiting options: no wait, fixed-time wait, or graceful wait. This led to unnecessary overhead, such as requiring `PhasedCell` to hold `AtomicUsize`, `Mutex`, and `Condvar` members just to enable graceful wait.

By having the `transition_to_cleanup` method accept a closure, the waiting process—like graceful wait—only needs to be executed within this closure when necessary.