### PR TITLE
fix: modified transition_to_cleanup so that the phase is set to Cleanup even if the closure fails

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,6 @@ pub enum PhasedErrorKind {
     PhaseIsAlreadyCleanup,
     DuringTransitionToRead,
     DuringTransitionToCleanup,
-    TransitionToReadFailed,
-    TransitionToCleanupFailed,
     FailToRunClosureDuringTransitionToRead,
     FailToRunClosureDuringTransitionToCleanup,
     StdMutexIsPoisoned,


### PR DESCRIPTION
This PR modified `transition_to_cleanup` methods so that the phase is not reverted and set to `Cleanup` even if the closure fails. This is because I judged it better to transition to the `Cleanup` phase and execute the termination process than to remain in the `Read` phase and be unable to execute termination when some abnormality occurs.