### PR TITLE
refactor: changed GracefulPhasedCell* not to use PhasedCell* internally

### DIFF
--- a/src/graceful/wait_async.rs
+++ b/src/graceful/wait_async.rs
@@ -7,19 +7,20 @@ use super::{GracefulWaitAsync, GracefulWaitError, GracefulWaitErrorKind};
 use std::{any, sync::atomic};
 use tokio::{sync, time};
 
+#[allow(clippy::new_without_default)]
 impl GracefulWaitAsync {
-    pub(crate) const fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             counter: atomic::AtomicUsize::new(0),
             notify: sync::Notify::const_new(),
         }
     }
 
-    pub(crate) fn count_up(&self) {
+    pub fn count_up(&self) {
         self.counter.fetch_add(1, atomic::Ordering::AcqRel);
     }
 
-    pub(crate) fn count_down<F>(&self, f: F)
+    pub fn count_down<F>(&self, f: F)
     where
         F: Fn() -> bool,
     {
@@ -47,7 +48,7 @@ impl GracefulWaitAsync {
         }
     }
 
-    pub(crate) async fn wait_gracefully_async(
+    pub async fn wait_gracefully_async(
         &self,
         timeout: time::Duration,
     ) -> Result<(), GracefulWaitError> {


### PR DESCRIPTION
This PR modifies the implementations of `GracefulPhasedCell`, `GracefulPhasedCellSync`, and `GracefulPhasedCellAsync` by removing their internal fields holding `PhasedCell`, `PhasedCellSync`, and `PhasedCellAsync` respectively, and instead implements the logic directly.

The reasons for this change are that the approach of executing the closure passed to `GracefulPhasedCell::transition_to_cleanup` inside the closure of `PhasedCell::transition_to_cleanup` felt a bit overly complex, and the previous implementation required the use of `Arc` and `LazyCell` within `GracefulPhasedCellAsync`.