### PR TITLE
fix: moved the position of graceful wait

### DIFF
--- a/src/graceful/phased_cell.rs
+++ b/src/graceful/phased_cell.rs
@@ -83,11 +83,11 @@ impl<T: Send + Sync> GracefulPhasedCell<T> {
             },
         ) {
             Ok(old_phase_cd) => {
+                let result_w = self.wait.wait_gracefully(timeout);
                 let current_phase_cd = match old_phase_cd {
                     PHASE_READ => PHASE_READ_TO_CLEANUP,
                     _ => PHASE_SETUP_TO_CLEANUP,
                 };
-                let result_w = self.wait.wait_gracefully(timeout);
                 let data = unsafe { &mut *self.data_cell.get() };
                 let result_f = f(data);
                 self.change_phase(current_phase_cd, PHASE_CLEANUP);

--- a/src/graceful/phased_cell_async.rs
+++ b/src/graceful/phased_cell_async.rs
@@ -99,8 +99,8 @@ impl<T: Send + Sync> GracefulPhasedCellAsync<T> {
             },
         ) {
             Ok(PHASE_READ) => {
-                let mut guard = self.data_mutex.lock().await;
                 let result_w = self.wait.wait_gracefully_async(timeout).await;
+                let mut guard = self.data_mutex.lock().await;
                 let data_opt = unsafe { &mut *self.data_cell.get() };
                 if data_opt.is_some() {
                     let result_f = f(data_opt.as_mut().unwrap()).await;


### PR DESCRIPTION
Closes #34

This PR moves the call to `GracefulWait#wait_gracefully` outside of the `data_mutex` lock.