### PR TITLE
fix!: renamed the method get_mut to get_mut_unlocked

### DIFF
--- a/tests/graceful_phased_cell_test.rs
+++ b/tests/graceful_phased_cell_test.rs
@@ -33,7 +33,7 @@ mod integration_tests_of_phased_cell {
     #[test]
     fn test() {
         for i in 0..3 {
-            match PHASED_CELL.get_mut() {
+            match PHASED_CELL.get_mut_unlocked() {
                 Ok(data) => {
                     data.add("A-".to_string() + &i.to_string());
                 }
@@ -69,7 +69,7 @@ mod integration_tests_of_phased_cell {
         }
 
         for i in 0..4 {
-            match PHASED_CELL.get_mut() {
+            match PHASED_CELL.get_mut_unlocked() {
                 Ok(data) => {
                     data.add("D-".to_string() + &i.to_string());
                 }
@@ -77,7 +77,7 @@ mod integration_tests_of_phased_cell {
             }
         }
 
-        match PHASED_CELL.get_mut() {
+        match PHASED_CELL.get_mut_unlocked() {
             Ok(data) => {
                 assert_eq!(
                     &data.vec,

--- a/tests/phased_cell_test.rs
+++ b/tests/phased_cell_test.rs
@@ -33,7 +33,7 @@ mod integration_tests_of_phased_cell {
     #[test]
     fn test() {
         for i in 0..3 {
-            match PHASED_CELL.get_mut() {
+            match PHASED_CELL.get_mut_unlocked() {
                 Ok(data) => {
                     data.add("A-".to_string() + &i.to_string());
                 }
@@ -71,7 +71,7 @@ mod integration_tests_of_phased_cell {
         }
 
         for i in 0..4 {
-            match PHASED_CELL.get_mut() {
+            match PHASED_CELL.get_mut_unlocked() {
                 Ok(data) => {
                     data.add("D-".to_string() + &i.to_string());
                 }
@@ -79,7 +79,7 @@ mod integration_tests_of_phased_cell {
             }
         }
 
-        match PHASED_CELL.get_mut() {
+        match PHASED_CELL.get_mut_unlocked() {
             Ok(data) => {
                 assert_eq!(
                     &data.vec,


### PR DESCRIPTION
This PR changes the method name of `get_mut` of `PhasedCell` and `GracefulPhasedCell` to `get_mut_unlocked`.
These methods aren't designed to be thread-safe, so they need to be given names that reflect this.