### PR TITLE
fix!: added the Copy trait to the Phase enum

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,6 +25,11 @@ impl PhasedError {
             source: Some(Box::new(e)),
         }
     }
+
+    /// Gets the phase in which the error occurred.
+    pub fn phase(&self) -> Phase {
+        self.phase
+    }
 }
 
 impl fmt::Debug for PhasedError {
@@ -64,7 +69,7 @@ mod tests_of_phased_error {
             PhasedErrorKind::CannotCallUnlessPhaseRead("method".to_string()),
         );
 
-        assert_eq!(e.phase, Phase::Setup);
+        assert_eq!(e.phase(), Phase::Setup);
         assert_eq!(
             e.kind,
             PhasedErrorKind::CannotCallUnlessPhaseRead("method".to_string())
@@ -81,7 +86,7 @@ mod tests_of_phased_error {
             e0,
         );
 
-        assert_eq!(e.phase, Phase::Setup);
+        assert_eq!(e.phase(), Phase::Setup);
         assert_eq!(
             e.kind,
             PhasedErrorKind::CannotCallUnlessPhaseRead("method".to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ use std::{cell, error, marker, sync::atomic};
 /// 1. `Setup`: The initial phase where the data is constructed and initialized.
 /// 2. `Read`: The main operational phase where the data is accessed for read-only operations.
 /// 3. `Cleanup`: The final phase where the data is deconstructed and resources are released.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Phase {
     /// The initial phase for setting up the data.
     Setup,
@@ -185,8 +185,7 @@ pub enum PhasedErrorKind {
 /// It contains the phase in which the error occurred, the kind of error, and an
 /// optional source error for more context.
 pub struct PhasedError {
-    /// The phase in which the error occurred.
-    pub phase: Phase,
+    phase: Phase,
     /// The kind of error that occurred.
     pub kind: PhasedErrorKind,
     source: Option<Box<dyn error::Error + Send + Sync>>,


### PR DESCRIPTION
This PR adds `Clone` and `Copy` traits to `Phase` enum, then changes the `phase` field of `PhasedError` to private and adds the `phase` public method to `PhasedError`.

By this, the values of `phase` fields of `PhasedError` instances become immutable.