### PR TITLE
fix!: added the Copy trait to the PhasedErrorKind enum

### DIFF
--- a/src/graceful/errors.rs
+++ b/src/graceful/errors.rs
@@ -10,6 +10,11 @@ impl GracefulWaitError {
     pub(crate) fn new(kind: GracefulWaitErrorKind) -> Self {
         Self { kind }
     }
+
+    /// The kind of error that occurred.
+    pub fn kind(&self) -> GracefulWaitErrorKind {
+        self.kind
+    }
 }
 
 impl fmt::Debug for GracefulWaitError {
@@ -44,7 +49,7 @@ mod tests_of_graceful_wait_error {
         ));
 
         assert_eq!(
-            e.kind,
+            e.kind(),
             GracefulWaitErrorKind::TimedOut(std::time::Duration::from_secs(1)),
         );
         assert!(e.source().is_none());

--- a/src/graceful/mod.rs
+++ b/src/graceful/mod.rs
@@ -77,7 +77,7 @@ pub struct GracefulWaitAsync {
 }
 
 /// An enumeration of possible error kinds that can occur during a graceful wait.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum GracefulWaitErrorKind {
     /// An error indicating that the wait timed out.
     TimedOut(std::time::Duration),
@@ -87,6 +87,5 @@ pub enum GracefulWaitErrorKind {
 
 /// A structure representing an error that occurred during a graceful wait.
 pub struct GracefulWaitError {
-    /// The kind of error that occurred.
-    pub kind: GracefulWaitErrorKind,
+    kind: GracefulWaitErrorKind,
 }

--- a/src/graceful/wait_async.rs
+++ b/src/graceful/wait_async.rs
@@ -155,7 +155,7 @@ mod graceful_wait_async {
             .await
         {
             assert_eq!(
-                e.kind,
+                e.kind(),
                 GracefulWaitErrorKind::TimedOut(time::Duration::from_secs(1),)
             );
         } else {

--- a/src/graceful/wait_sync.rs
+++ b/src/graceful/wait_sync.rs
@@ -168,7 +168,7 @@ mod graceful_wait_sync {
 
         if let Err(e) = wait.wait_gracefully(std::time::Duration::from_secs(1)) {
             assert_eq!(
-                e.kind,
+                e.kind(),
                 GracefulWaitErrorKind::TimedOut(std::time::Duration::from_secs(1)),
             );
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,14 +149,14 @@ pub enum Phase {
 ///
 /// This enum categorizes the various errors that can arise during phase transitions
 /// or data access, providing specific information about the nature of the failure.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PhasedErrorKind {
     /// An error indicating that a method was called before or after the `Read` phase.
-    CannotCallUnlessPhaseRead(String),
+    CannotCallUnlessPhaseRead(&'static str),
     /// An error indicating that a method was called during the `Setup` phase.
-    CannotCallOnPhaseSetup(String),
+    CannotCallOnPhaseSetup(&'static str),
     /// An error indicating that a method was called during the `Read` phase.
-    CannotCallOnPhaseRead(String),
+    CannotCallOnPhaseRead(&'static str),
     /// An error indicating that the internal data is not available.
     InternalDataUnavailable,
     /// An error indicating that the phase is already `Read`.
@@ -186,8 +186,7 @@ pub enum PhasedErrorKind {
 /// optional source error for more context.
 pub struct PhasedError {
     phase: Phase,
-    /// The kind of error that occurred.
-    pub kind: PhasedErrorKind,
+    kind: PhasedErrorKind,
     source: Option<Box<dyn error::Error + Send + Sync>>,
 }
 

--- a/tests/graceful_phased_cell_async_test.rs
+++ b/tests/graceful_phased_cell_async_test.rs
@@ -64,8 +64,8 @@ mod integration_tests_of_graceful_phased_cell_async {
                     .await
                 {
                     assert!(
-                        e.kind == PhasedErrorKind::DuringTransitionToRead
-                            || e.kind == PhasedErrorKind::PhaseIsAlreadyRead,
+                        e.kind() == PhasedErrorKind::DuringTransitionToRead
+                            || e.kind() == PhasedErrorKind::PhaseIsAlreadyRead,
                     )
                 }
             });
@@ -104,8 +104,8 @@ mod integration_tests_of_graceful_phased_cell_async {
                     .await
                 {
                     assert!(
-                        e.kind == PhasedErrorKind::PhaseIsAlreadyCleanup
-                            || e.kind == PhasedErrorKind::DuringTransitionToCleanup
+                        e.kind() == PhasedErrorKind::PhaseIsAlreadyCleanup
+                            || e.kind() == PhasedErrorKind::DuringTransitionToCleanup
                     );
                 }
             });

--- a/tests/graceful_phased_cell_sync_test.rs
+++ b/tests/graceful_phased_cell_sync_test.rs
@@ -58,8 +58,8 @@ mod integration_tests_of_graceful_phased_cell_sync {
                     Ok::<(), MyError>(())
                 }) {
                     assert!(
-                        e.kind == PhasedErrorKind::PhaseIsAlreadyRead
-                            || e.kind == PhasedErrorKind::DuringTransitionToRead
+                        e.kind() == PhasedErrorKind::PhaseIsAlreadyRead
+                            || e.kind() == PhasedErrorKind::DuringTransitionToRead
                     );
                 }
             });
@@ -97,8 +97,8 @@ mod integration_tests_of_graceful_phased_cell_sync {
                     })
                 {
                     assert!(
-                        e.kind == PhasedErrorKind::PhaseIsAlreadyCleanup
-                            || e.kind == PhasedErrorKind::DuringTransitionToCleanup
+                        e.kind() == PhasedErrorKind::PhaseIsAlreadyCleanup
+                            || e.kind() == PhasedErrorKind::DuringTransitionToCleanup
                     );
                 }
             });

--- a/tests/phased_cell_async_test.rs
+++ b/tests/phased_cell_async_test.rs
@@ -63,8 +63,8 @@ mod integration_tests_of_phased_cell_async {
                     .await
                 {
                     assert!(
-                        e.kind == PhasedErrorKind::DuringTransitionToRead
-                            || e.kind == PhasedErrorKind::PhaseIsAlreadyRead,
+                        e.kind() == PhasedErrorKind::DuringTransitionToRead
+                            || e.kind() == PhasedErrorKind::PhaseIsAlreadyRead,
                     )
                 }
             });
@@ -106,8 +106,8 @@ mod integration_tests_of_phased_cell_async {
                     .await
                 {
                     assert!(
-                        e.kind == PhasedErrorKind::PhaseIsAlreadyCleanup
-                            || e.kind == PhasedErrorKind::DuringTransitionToCleanup
+                        e.kind() == PhasedErrorKind::PhaseIsAlreadyCleanup
+                            || e.kind() == PhasedErrorKind::DuringTransitionToCleanup
                     );
                 }
             });

--- a/tests/phased_cell_sync_test.rs
+++ b/tests/phased_cell_sync_test.rs
@@ -57,8 +57,8 @@ mod integration_tests_of_phased_cell_sync {
                     Ok::<(), MyError>(())
                 }) {
                     assert!(
-                        e.kind == PhasedErrorKind::PhaseIsAlreadyRead
-                            || e.kind == PhasedErrorKind::DuringTransitionToRead
+                        e.kind() == PhasedErrorKind::PhaseIsAlreadyRead
+                            || e.kind() == PhasedErrorKind::DuringTransitionToRead
                     );
                 }
             });
@@ -97,8 +97,8 @@ mod integration_tests_of_phased_cell_sync {
                     Ok::<(), MyError>(())
                 }) {
                     assert!(
-                        e.kind == PhasedErrorKind::PhaseIsAlreadyCleanup
-                            || e.kind == PhasedErrorKind::DuringTransitionToCleanup
+                        e.kind() == PhasedErrorKind::PhaseIsAlreadyCleanup
+                            || e.kind() == PhasedErrorKind::DuringTransitionToCleanup
                     );
                 }
             });


### PR DESCRIPTION
This PR adds `Clone` and `Copy` traits to `PhasedErrorKind` enum, then changes the `kind` field of `PhasedError` to private and adds the phase public method to `PhasedError`.

By this, the values of `kind` fields of `PhasedError` instances become immutable.