### PR TITLE
new: introduced read_ready/read_ready_async methods waiting for read phase transition to complete

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,11 +6,12 @@ use crate::{Phase, PhasedError, PhasedErrorKind};
 
 use std::{any, error, fmt};
 
-pub(crate) const METHOD_READ: &'static str = "read";
-pub(crate) const METHOD_READ_RELAXED: &'static str = "read_relaxed";
-pub(crate) const METHOD_GET_MUT_UNLOCKED: &'static str = "get_mut_unlocked";
-pub(crate) const METHOD_LOCK: &'static str = "lock";
-pub(crate) const METHOD_LOCK_ASYNC: &'static str = "lock_async";
+pub(crate) const METHOD_READ: &str = "read";
+pub(crate) const METHOD_READ_RELAXED: &str = "read_relaxed";
+pub(crate) const METHOD_GET_MUT_UNLOCKED: &str = "get_mut_unlocked";
+pub(crate) const METHOD_LOCK: &str = "lock";
+#[cfg(feature = "setup_read_cleanup-on-tokio")]
+pub(crate) const METHOD_LOCK_ASYNC: &str = "lock_async";
 
 impl PhasedError {
     pub(crate) fn new(phase: Phase, kind: PhasedErrorKind) -> Self {

--- a/src/graceful/phased_cell_async.rs
+++ b/src/graceful/phased_cell_async.rs
@@ -71,8 +71,11 @@ impl<T: Send + Sync> GracefulPhasedCellAsync<T> {
 
     /// Returns a reference to the contained data with relaxed memory ordering.
     ///
-    /// This method is only successful if the cell is in the `Read` phase.
-    /// It increments the internal counter to track active readers for graceful shutdown.
+    /// This method attempts to return a reference to the contained data immediately without
+    /// waiting.
+    /// It is only successful if the cell is in the `Read` phase. It increments the internal counter
+    /// to track active readers for graceful shutdown.
+    /// It provides weaker memory ordering guarantees.
     ///
     /// # Errors
     ///
@@ -99,14 +102,55 @@ impl<T: Send + Sync> GracefulPhasedCellAsync<T> {
 
     /// Returns a reference to the contained data with acquire memory ordering.
     ///
-    /// This method is only successful if the cell is in the `Read` phase.
-    /// It increments the internal counter to track active readers for graceful shutdown.
+    /// This method attempts to return a reference to the contained data immediately without
+    /// waiting.
+    /// It is only successful if the cell is in the `Read` phase. It increments the internal counter
+    /// to track active readers for graceful shutdown.
+    /// It provides stronger memory ordering guarantees than `read_relaxed`.
     ///
     /// # Errors
     ///
     /// Returns an error if the cell is not in the `Read` phase or the data is unavailable.
     pub fn read(&self) -> Result<&T, PhasedError> {
         let phase = self.phase.load(atomic::Ordering::Acquire);
+        if phase != PHASE_READ {
+            return Err(PhasedError::new(
+                u8_to_phase(phase),
+                PhasedErrorKind::CannotCallUnlessPhaseRead(METHOD_READ),
+            ));
+        }
+
+        if let Some(data) = unsafe { &*self.data_cell.get() }.as_ref() {
+            self.wait.count_up();
+            Ok(data)
+        } else {
+            Err(PhasedError::new(
+                u8_to_phase(phase),
+                PhasedErrorKind::InternalDataUnavailable,
+            ))
+        }
+    }
+
+    /// Returns a reference to the contained data with acquire memory ordering.
+    ///
+    /// In contrast to `read`, this asynchronous method awaits until the cell is in the `Read`
+    /// phase, or until the transition from `Setup` to `Read` phase is complete.
+    /// It is only successful if the cell is in the `Read` phase. It increments the internal counter
+    /// to track active readers for graceful shutdown.
+    /// It provides stronger memory ordering guarantees.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the cell is not in the `Read` phase after waiting, or the data is
+    /// unavailable.
+    pub async fn read_ready_async(&self) -> Result<&T, PhasedError> {
+        let mut phase = self.phase.load(atomic::Ordering::Acquire);
+        if phase == PHASE_SETUP_TO_READ {
+            // wait for transitioning to read
+            let _ = self.data_mutex.lock().await;
+            phase = self.phase.load(atomic::Ordering::Acquire);
+        }
+
         if phase != PHASE_READ {
             return Err(PhasedError::new(
                 u8_to_phase(phase),
@@ -140,7 +184,8 @@ impl<T: Send + Sync> GracefulPhasedCellAsync<T> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the wait times out, the phase transition fails, or the closure returns an error.
+    /// Returns an error if the wait times out, the phase transition fails, or the closure returns
+    /// an error.
     pub async fn transition_to_cleanup_async<F, E>(
         &self,
         timeout: time::Duration,
@@ -1416,5 +1461,109 @@ mod tests_of_phased_cell_async {
         }
 
         assert!(counter.load(atomic::Ordering::Acquire) < 10);
+    }
+
+    #[tokio::test]
+    async fn read_ready_async_waits_for_transition() {
+        let cell = Arc::new(GracefulPhasedCellAsync::new(MyStruct::new()));
+        assert_eq!(cell.phase(), Phase::Setup);
+
+        let cell_clone = Arc::clone(&cell);
+        let handler = tokio::spawn(async move {
+            cell_clone
+                .transition_to_read_async(|_data| {
+                    Box::pin(async {
+                        tokio::time::sleep(time::Duration::from_millis(100)).await;
+                        Ok::<(), MyError>(())
+                    })
+                })
+                .await
+                .unwrap();
+        });
+
+        tokio::time::sleep(time::Duration::from_millis(10)).await;
+
+        let data = cell.read_ready_async().await.unwrap();
+        assert_eq!(cell.phase(), Phase::Read);
+        assert_eq!(data.vec.len(), 0);
+        cell.finish_reading();
+
+        handler.await.unwrap();
+        assert_eq!(cell.phase(), Phase::Read);
+    }
+
+    #[tokio::test]
+    async fn read_ready_async_on_read_phase() {
+        let cell = GracefulPhasedCellAsync::new(MyStruct::new());
+        cell.transition_to_read_async(|_| Box::pin(async { Ok::<(), MyError>(()) }))
+            .await
+            .unwrap();
+        assert_eq!(cell.phase(), Phase::Read);
+
+        let data = cell.read_ready_async().await.unwrap();
+        assert_eq!(data.vec.len(), 0);
+        cell.finish_reading();
+    }
+
+    #[tokio::test]
+    async fn fail_to_read_ready_async_if_phase_is_setup() {
+        let cell = GracefulPhasedCellAsync::new(MyStruct::new());
+        assert_eq!(cell.phase(), Phase::Setup);
+
+        if let Err(e) = cell.read_ready_async().await {
+            assert_eq!(e.phase(), Phase::Setup);
+            assert_eq!(e.kind(), PhasedErrorKind::CannotCallUnlessPhaseRead("read"));
+        } else {
+            panic!();
+        }
+    }
+
+    #[tokio::test]
+    async fn fail_to_read_ready_async_if_phase_is_cleanup() {
+        let cell = GracefulPhasedCellAsync::new(MyStruct::new());
+        cell.transition_to_cleanup_async(time::Duration::ZERO, |_| {
+            Box::pin(async { Ok::<(), MyError>(()) })
+        })
+        .await
+        .unwrap();
+        assert_eq!(cell.phase(), Phase::Cleanup);
+
+        if let Err(e) = cell.read_ready_async().await {
+            assert_eq!(e.phase(), Phase::Cleanup);
+            assert_eq!(e.kind(), PhasedErrorKind::CannotCallUnlessPhaseRead("read"));
+        } else {
+            panic!();
+        }
+    }
+
+    #[tokio::test]
+    async fn read_ready_async_returns_error_if_transition_fails() {
+        let cell = Arc::new(GracefulPhasedCellAsync::new(MyStruct::new()));
+        assert_eq!(cell.phase(), Phase::Setup);
+
+        let cell_clone = Arc::clone(&cell);
+        let handler = tokio::spawn(async move {
+            cell_clone
+                .transition_to_read_async(|_data| {
+                    Box::pin(async {
+                        tokio::time::sleep(time::Duration::from_millis(100)).await;
+                        Err(MyError {})
+                    })
+                })
+                .await
+                .unwrap_err();
+        });
+
+        tokio::time::sleep(time::Duration::from_millis(10)).await;
+
+        if let Err(e) = cell.read_ready_async().await {
+            assert_eq!(e.phase(), Phase::Setup);
+            assert_eq!(e.kind(), PhasedErrorKind::CannotCallUnlessPhaseRead("read"));
+        } else {
+            panic!();
+        }
+
+        handler.await.unwrap();
+        assert_eq!(cell.phase(), Phase::Setup);
     }
 }

--- a/src/graceful/phased_cell_sync.rs
+++ b/src/graceful/phased_cell_sync.rs
@@ -68,8 +68,11 @@ impl<T: Send + Sync> GracefulPhasedCellSync<T> {
 
     /// Returns a reference to the contained data with relaxed memory ordering.
     ///
-    /// This method is only successful if the cell is in the `Read` phase.
-    /// It increments the internal counter to track active readers for graceful shutdown.
+    /// This method attempts to return a reference to the contained data immediately without
+    /// waiting.
+    /// It is only successful if the cell is in the `Read` phase. It increments the internal counter
+    /// to track active readers for graceful shutdown.
+    /// It provides weaker memory ordering guarantees.
     ///
     /// # Errors
     ///
@@ -96,14 +99,60 @@ impl<T: Send + Sync> GracefulPhasedCellSync<T> {
 
     /// Returns a reference to the contained data with acquire memory ordering.
     ///
-    /// This method is only successful if the cell is in the `Read` phase.
-    /// It increments the internal counter to track active readers for graceful shutdown.
+    /// This method attempts to return a reference to the contained data immediately without
+    /// waiting.
+    /// It is only successful if the cell is in the `Read` phase. It increments the internal counter
+    /// to track active readers for graceful shutdown.
+    /// It provides stronger memory ordering guarantees than `read_relaxed`.
     ///
     /// # Errors
     ///
     /// Returns an error if the cell is not in the `Read` phase or the data is unavailable.
     pub fn read(&self) -> Result<&T, PhasedError> {
         let phase = self.phase.load(atomic::Ordering::Acquire);
+        if phase != PHASE_READ {
+            return Err(PhasedError::new(
+                u8_to_phase(phase),
+                PhasedErrorKind::CannotCallUnlessPhaseRead(METHOD_READ),
+            ));
+        }
+
+        if let Some(data) = unsafe { &*self.data_cell.get() }.as_ref() {
+            self.wait.count_up();
+            Ok(data)
+        } else {
+            Err(PhasedError::new(
+                u8_to_phase(phase),
+                PhasedErrorKind::InternalDataUnavailable,
+            ))
+        }
+    }
+
+    /// Returns a reference to the contained data with acquire memory ordering, blocking if necessary.
+    ///
+    /// In contrast to `read`, this method blocks the current thread to wait for the transition to
+    /// complete if the cell is in the process of transitioning from `Setup` to `Read` phase.
+    /// It is only successful if the cell is in the `Read` phase. It increments the internal counter
+    /// to track active readers for graceful shutdown.
+    /// It provides stronger memory ordering guarantees.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the cell is not in the `Read` phase after waiting, or the data is unavailable,
+    /// or if the mutex is poisoned while waiting.
+    pub fn read_ready(&self) -> Result<&T, PhasedError> {
+        let mut phase = self.phase.load(atomic::Ordering::Acquire);
+        if phase == PHASE_SETUP_TO_READ {
+            // wait for transitioning to read
+            if self.data_mutex.lock().is_err() {
+                return Err(PhasedError::new(
+                    u8_to_phase(PHASE_SETUP_TO_READ),
+                    PhasedErrorKind::StdMutexIsPoisoned,
+                ));
+            }
+            phase = self.phase.load(atomic::Ordering::Acquire);
+        }
+
         if phase != PHASE_READ {
             return Err(PhasedError::new(
                 u8_to_phase(phase),
@@ -408,7 +457,7 @@ mod tests_of_phased_cell_sync {
     use std::error::Error;
     use std::fmt;
     use std::sync::Arc;
-    use tokio::time;
+    use std::time;
 
     #[derive(Debug)]
     struct MyStruct {
@@ -1365,5 +1414,98 @@ mod tests_of_phased_cell_sync {
         }
 
         assert!(counter.load(atomic::Ordering::Acquire) < 10);
+    }
+
+    #[test]
+    fn read_ready_waits_for_transition() {
+        let cell = Arc::new(GracefulPhasedCellSync::new(MyStruct::new()));
+        assert_eq!(cell.phase(), Phase::Setup);
+
+        let cell_clone = Arc::clone(&cell);
+        let handler = std::thread::spawn(move || {
+            cell_clone
+                .transition_to_read(|_data| {
+                    std::thread::sleep(time::Duration::from_millis(100));
+                    Ok::<(), MyError>(())
+                })
+                .unwrap();
+        });
+
+        std::thread::sleep(time::Duration::from_millis(10));
+
+        let data = cell.read_ready().unwrap();
+        assert_eq!(cell.phase(), Phase::Read);
+        assert_eq!(data.vec.len(), 0);
+        cell.finish_reading();
+
+        handler.join().unwrap();
+        assert_eq!(cell.phase(), Phase::Read);
+    }
+
+    #[test]
+    fn read_ready_on_read_phase() {
+        let cell = GracefulPhasedCellSync::new(MyStruct::new());
+        cell.transition_to_read(|_| Ok::<(), MyError>(())).unwrap();
+        assert_eq!(cell.phase(), Phase::Read);
+
+        let data = cell.read_ready().unwrap();
+        assert_eq!(data.vec.len(), 0);
+        cell.finish_reading();
+    }
+
+    #[test]
+    fn fail_to_read_ready_if_phase_is_setup() {
+        let cell = GracefulPhasedCellSync::new(MyStruct::new());
+        assert_eq!(cell.phase(), Phase::Setup);
+
+        if let Err(e) = cell.read_ready() {
+            assert_eq!(e.phase(), Phase::Setup);
+            assert_eq!(e.kind(), PhasedErrorKind::CannotCallUnlessPhaseRead("read"));
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn fail_to_read_ready_if_phase_is_cleanup() {
+        let cell = GracefulPhasedCellSync::new(MyStruct::new());
+        cell.transition_to_cleanup(time::Duration::ZERO, |_| Ok::<(), MyError>(()))
+            .unwrap();
+        assert_eq!(cell.phase(), Phase::Cleanup);
+
+        if let Err(e) = cell.read_ready() {
+            assert_eq!(e.phase(), Phase::Cleanup);
+            assert_eq!(e.kind(), PhasedErrorKind::CannotCallUnlessPhaseRead("read"));
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn read_ready_returns_error_if_transition_fails() {
+        let cell = Arc::new(GracefulPhasedCellSync::new(MyStruct::new()));
+        assert_eq!(cell.phase(), Phase::Setup);
+
+        let cell_clone = Arc::clone(&cell);
+        let handler = std::thread::spawn(move || {
+            cell_clone
+                .transition_to_read(|_data| {
+                    std::thread::sleep(time::Duration::from_millis(100));
+                    Err(MyError {})
+                })
+                .unwrap_err();
+        });
+
+        std::thread::sleep(time::Duration::from_millis(10));
+
+        if let Err(e) = cell.read_ready() {
+            assert_eq!(e.phase(), Phase::Setup);
+            assert_eq!(e.kind(), PhasedErrorKind::CannotCallUnlessPhaseRead("read"));
+        } else {
+            panic!();
+        }
+
+        handler.join().unwrap();
+        assert_eq!(cell.phase(), Phase::Setup);
     }
 }

--- a/tests/graceful_phased_cell_async_test.rs
+++ b/tests/graceful_phased_cell_async_test.rs
@@ -1,4 +1,8 @@
-#[cfg(test)]
+#[cfg(all(
+    test,
+    feature = "setup_read_cleanup-graceful",
+    feature = "setup_read_cleanup-on-tokio"
+))]
 mod integration_tests_of_graceful_phased_cell_async {
     use setup_read_cleanup::{graceful::GracefulPhasedCellAsync, PhasedErrorKind};
     use std::{error, fmt};

--- a/tests/graceful_phased_cell_sync_test.rs
+++ b/tests/graceful_phased_cell_sync_test.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "setup_read_cleanup-graceful"))]
 mod integration_tests_of_graceful_phased_cell_sync {
     use setup_read_cleanup::{graceful::GracefulPhasedCellSync, PhasedErrorKind};
     use std::{error, fmt, thread, time};

--- a/tests/graceful_phased_cell_test.rs
+++ b/tests/graceful_phased_cell_test.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "setup_read_cleanup-graceful"))]
 mod integration_tests_of_phased_cell {
     use setup_read_cleanup::graceful::GracefulPhasedCell;
     use std::{error, fmt, thread, time};

--- a/tests/phased_cell_async_test.rs
+++ b/tests/phased_cell_async_test.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[cfg(feature = "setup_read_cleanup-on-tokio")]
 mod integration_tests_of_phased_cell_async {
     use setup_read_cleanup::{PhasedCellAsync, PhasedErrorKind};
     use std::{error, fmt};


### PR DESCRIPTION
Closes #49 

### Summary:

This PR introduces `read_ready` and `read_ready_async` to provide a safe way to read data by waiting for a phase transition to complete. This change prevents race conditions where multiple read attempts during the transition from `Setup` to `Read` phase could previously lead to errors. Existing `read` and `read_relaxed` methods are now strictly non-waiting.

### Motivation:

When a phase transition is initiated (e.g., by the first read attempt), subsequent concurrent calls to `read` would fail because the cell is in the temporary `SETUP_TO_READ` phase. The goal of this change is to allow these subsequent read calls to wait for the transition to complete and then successfully read the data, rather than erroring out.

### Changes:

* `read` & `read_relaxed`: These methods now always return an error immediately if the cell is not in the `Read` phase. They do not wait.
* `read_ready` (Sync): This new method blocks the current thread and waits for the Setup-to-Read transition to finish before reading the data.
* `read_ready_async` (Async): This new method asynchronously awaits the completion of the Setup-to-Read transition before reading the data.

This new API structure provides a clear and safe mechanism for handling concurrent reads during phase transitions.