### PR TITLE
cicd: updated rust version targeted by ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rustver: ['1.74.1', '1.79.0', '1.89.0', '1.91.0']
+        rustver: ['1.74.1', '1.79.0', '1.89.0', '1.91.1']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This PR updates the Rust versions targeted by CI to `〜1.91.1`.