### PR TITLE
update!: hid GracefulWaitSync, GracefulWaitAsync, etc. in graceful module

### DIFF
--- a/src/graceful/errors.rs
+++ b/src/graceful/errors.rs
@@ -10,11 +10,6 @@ impl GracefulWaitError {
     pub(crate) fn new(kind: GracefulWaitErrorKind) -> Self {
         Self { kind }
     }
-
-    /// The kind of error that occurred.
-    pub fn kind(&self) -> GracefulWaitErrorKind {
-        self.kind
-    }
 }
 
 impl fmt::Debug for GracefulWaitError {
@@ -49,7 +44,7 @@ mod tests_of_graceful_wait_error {
         ));
 
         assert_eq!(
-            e.kind(),
+            e.kind,
             GracefulWaitErrorKind::TimedOut(std::time::Duration::from_secs(1)),
         );
         assert!(e.source().is_none());

--- a/src/graceful/mod.rs
+++ b/src/graceful/mod.rs
@@ -40,11 +40,7 @@ pub struct GracefulPhasedCellSync<T: Send + Sync> {
     _marker: marker::PhantomData<T>,
 }
 
-/// A synchronization primitive for graceful cleanup in synchronous contexts.
-///
-/// `GracefulWaitSync` is used by `GracefulPhasedCellSync` to block the cleanup process
-/// until all read operations have completed.
-pub struct GracefulWaitSync {
+pub(crate) struct GracefulWaitSync {
     counter: atomic::AtomicUsize,
     blocker: std::sync::Mutex<bool>,
     condvar: std::sync::Condvar,
@@ -65,27 +61,19 @@ pub struct GracefulPhasedCellAsync<T: Send + Sync> {
     _marker: marker::PhantomData<T>,
 }
 
-/// A synchronization primitive for graceful cleanup in asynchronous contexts.
-///
-/// `GracefulWaitAsync` is used by `GracefulPhasedCellAsync` to await the completion
-/// of all read operations before cleanup.
 #[cfg(feature = "setup_read_cleanup-on-tokio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "setup_read_cleanup-on-tokio")))]
-pub struct GracefulWaitAsync {
+pub(crate) struct GracefulWaitAsync {
     counter: atomic::AtomicUsize,
     notify: tokio::sync::Notify,
 }
 
-/// An enumeration of possible error kinds that can occur during a graceful wait.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum GracefulWaitErrorKind {
-    /// An error indicating that the wait timed out.
+pub(crate) enum GracefulWaitErrorKind {
     TimedOut(std::time::Duration),
-    /// An error indicating that a mutex is poisoned.
     MutexIsPoisoned,
 }
 
-/// A structure representing an error that occurred during a graceful wait.
-pub struct GracefulWaitError {
+pub(crate) struct GracefulWaitError {
     kind: GracefulWaitErrorKind,
 }

--- a/src/graceful/wait_async.rs
+++ b/src/graceful/wait_async.rs
@@ -155,7 +155,7 @@ mod graceful_wait_async {
             .await
         {
             assert_eq!(
-                e.kind(),
+                e.kind,
                 GracefulWaitErrorKind::TimedOut(time::Duration::from_secs(1),)
             );
         } else {

--- a/src/graceful/wait_sync.rs
+++ b/src/graceful/wait_sync.rs
@@ -168,7 +168,7 @@ mod graceful_wait_sync {
 
         if let Err(e) = wait.wait_gracefully(std::time::Duration::from_secs(1)) {
             assert_eq!(
-                e.kind(),
+                e.kind,
                 GracefulWaitErrorKind::TimedOut(std::time::Duration::from_secs(1)),
             );
         } else {


### PR DESCRIPTION
This PR hides `GracefulWaitSync`, `GracefulWaitAsync`, `GracefulWaitError`, and `GracefulWaitErrorKind` are no longer public. 
This changes are preparation for a future rewrite of the graceful module, and related to #53. 