### PR TITLE
feat: added panic handling for panics by the closures of transition_to_* methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ categories = ["concurrency", "asynchronous", "rust-patterns"]
 
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"], optional = true }
+futures = { version = "0.3", optional = true }
 
 [features]
-setup_read_cleanup-on-tokio = ["tokio"]
+setup_read_cleanup-on-tokio = ["tokio", "futures"]
 setup_read_cleanup-graceful = []
 default = []
 full = ["setup_read_cleanup-on-tokio", "setup_read_cleanup-graceful"]


### PR DESCRIPTION
This change introduces robust panic handling for closures executed within `transition_to_read` and `transition_to_cleanup` methods across all `PhasedCell` variants (`PhasedCell`, `PhasedCellSync`, `PhasedCellAsync`, and their `Graceful` counterparts).

Previously, a panic within these closures could leave the `PhasedCell` in an inconsistent intermediate state. With this update:

   - If a closure panics during `transition_to_read`, the cell's phase is safely reverted to `Setup`.
   - If a closure panics during `transition_to_cleanup`, the cell's phase is safely moved to `Cleanup`.
   - All acquired mutexes are released before the panic is resumed, preventing deadlocks.
   - The original panic is re-propagated, maintaining Rust's panic-safety guarantees.

  This enhances the reliability and robustness of `PhasedCell` by ensuring consistent state management even in the presence of panicking user-provided code.