### PR TITLE
cicd: upgrade the target rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rustver: ['1.74.1', '1.79.0', '1.89.0', '1.91.1']
+        rustver: ['1.74.1', '1.79.0', '1.89.0', '1.92.0']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This PR updates the latest rust version in CI to `1.92.0`.