### PR TITLE
refactor: changed to use conditional impl with Send+Sync bounds for type param of PhasedCell/GracefulPhasedCell

### DIFF
--- a/src/graceful/mod.rs
+++ b/src/graceful/mod.rs
@@ -19,7 +19,9 @@ use std::{cell, marker, sync::atomic};
 /// 2. **Graceful Read**: If a read operation is attempted while the cell is in the
 ///    `Setup` phase and transitioning to `Read`, the read operation
 ///    will wait for the transition to complete and for the cell to enter the `Read` phase.
-pub struct GracefulPhasedCell<T: Send + Sync> {
+///
+/// Like `PhasedCell`, this cell is `Sync` if the contained data `T` is `Send + Sync`.
+pub struct GracefulPhasedCell<T> {
     phase: atomic::AtomicU8,
     graceful_counter: atomic::AtomicUsize,
     graceful_condvar: std::sync::Condvar,

--- a/src/graceful/phased_cell.rs
+++ b/src/graceful/phased_cell.rs
@@ -10,10 +10,16 @@ const MAX_READ_COUNT: usize = (isize::MAX) as usize;
 
 use std::{any, cell, error, marker, sync, sync::atomic, time};
 
+// conditional implementation:
+// `GracefulPhasedCell<T>` can be created with any `T`.
+// These `impl`s ensure that `GracefulPhasedCell<T>` is only `Send` or `Sync` if `T` is.
+// Attempting to use a `GracefulPhasedCell<T>` across threads (e.g. in an `Arc`) where
+// `T` is not `Send + Sync` will result in a compile-time error, thus preserving
+// thread safety without restricting single-threaded usage.
+unsafe impl<T: Send> Send for GracefulPhasedCell<T> {}
 unsafe impl<T: Send + Sync> Sync for GracefulPhasedCell<T> {}
-unsafe impl<T: Send + Sync> Send for GracefulPhasedCell<T> {}
 
-impl<T: Send + Sync> GracefulPhasedCell<T> {
+impl<T> GracefulPhasedCell<T> {
     /// Creates a new `GracefulPhasedCell` in the `Setup` phase, containing the provided data.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,10 @@
 //!
 //! This crate offers several cell variants to suit different concurrency needs:
 //!
-//! - [`PhasedCell`]: The basic cell. It is `Sync`, allowing it to be shared across
-//!   threads for reading. However, mutable access via [`get_mut_unlocked`](PhasedCell::get_mut_unlocked)
-//!   is not thread-safe and requires the caller to ensure exclusive access.
+//! - [`PhasedCell`]: The basic cell. It is `Sync` if the contained data `T` is `Send + Sync`,
+//!   allowing it to be shared across threads for reading. However, mutable access via
+//!   [`get_mut_unlocked`](PhasedCell::get_mut_unlocked) is not thread-safe and requires the
+//!   caller to ensure exclusive access.
 //!
 //! - [`PhasedCellSync`]: A thread-safe version that uses a `std::sync::Mutex` to allow for
 //!   safe concurrent mutable access during the `Setup` and `Cleanup` phases.
@@ -201,11 +202,12 @@ pub struct PhasedError {
 /// phase, a read-only operational period in the `Read` phase, and deconstruction
 /// in the `Cleanup` phase.
 ///
-/// This cell is `Sync`, allowing it to be shared across threads. During the `Read`
-/// phase, the `read` and `read_relaxed` methods can be safely called from multiple
-/// threads simultaneously. Access during phase transitions and mutable access in
+/// This cell is `Sync` if the contained data `T` is `Send + Sync`, which allows
+/// the cell to be shared across threads. During the `Read` phase, the `read` and
+/// `read_relaxed` methods can be safely called from multiple threads simultaneously
+/// if the cell is `Sync`. Access during phase transitions and mutable access in
 /// other phases are not thread-safe.
-pub struct PhasedCell<T: Send + Sync> {
+pub struct PhasedCell<T> {
     phase: atomic::AtomicU8,
     data_cell: cell::UnsafeCell<T>,
     _marker: marker::PhantomData<T>,

--- a/src/phased_cell.rs
+++ b/src/phased_cell.rs
@@ -7,10 +7,16 @@ use crate::{Phase, PhasedCell, PhasedError, PhasedErrorKind};
 
 use std::{cell, error, marker, sync::atomic};
 
+// conditional implementation:
+// `PhasedCell<T>` can be created with any `T`.
+// These `impl`s ensure that `PhasedCell<T>` is only `Send` or `Sync` if `T` is.
+// Attempting to use a `PhasedCell<T>` across threads (e.g. in an `Arc`) where
+// `T` is not `Send + Sync` will result in a compile-time error, thus preserving
+// thread safety without restricting single-threaded usage.
+unsafe impl<T: Send> Send for PhasedCell<T> {}
 unsafe impl<T: Send + Sync> Sync for PhasedCell<T> {}
-unsafe impl<T: Send + Sync> Send for PhasedCell<T> {}
 
-impl<T: Send + Sync> PhasedCell<T> {
+impl<T> PhasedCell<T> {
     /// Creates a new `PhasedCell` in the `Setup` phase, containing the provided data.
     ///
     /// # Examples

--- a/tests/conditional_data_send_sync_impl_test.rs
+++ b/tests/conditional_data_send_sync_impl_test.rs
@@ -1,0 +1,192 @@
+// This test file verifies two key aspects of the PhasedCell and GracefulPhasedCell
+// after the conditional implementation refactoring:
+//
+// 1. **Flexibility:** PhasedCells can now hold non-`Send` or non-`Sync` data
+//    (like `Rc<T>` or `Cell<T>`) for single-threaded use cases.
+// 2. **Concurrency:** The original multi-threaded capabilities for `Send + Sync` data
+//    remain fully functional, and thread-safety is enforced at compile-time
+//    if one attempts to share a cell holding non-`Sync` data.
+
+use setup_read_cleanup::{Phase, PhasedCell};
+
+#[cfg(feature = "setup_read_cleanup-graceful")]
+use setup_read_cleanup::graceful::GracefulPhasedCell;
+
+use std::rc::Rc;
+use std::sync::Arc;
+use std::thread;
+
+#[cfg(feature = "setup_read_cleanup-graceful")]
+use std::time::Duration;
+
+#[cfg(test)]
+mod tests_of_phased_cell {
+    use super::*;
+
+    #[test]
+    fn test_single_threaded_with_non_sync_data() {
+        let cell = PhasedCell::new(Rc::new(String::from("hello")));
+
+        cell.get_mut_unlocked()
+            .map(|rc_str| *Rc::get_mut(rc_str).unwrap() = String::from("setup"))
+            .unwrap();
+
+        cell.transition_to_read(|rc_str: &mut Rc<String>| {
+            *Rc::get_mut(rc_str).unwrap() = String::from("read");
+            Ok::<(), std::io::Error>(())
+        })
+        .unwrap();
+
+        let data = cell.read().unwrap();
+        assert_eq!(**data, "read");
+        let _ = data;
+
+        cell.transition_to_cleanup(|rc_str: &mut Rc<String>| {
+            *Rc::get_mut(rc_str).unwrap() = String::from("cleanup");
+            Ok::<(), std::io::Error>(())
+        })
+        .unwrap();
+        assert_eq!(cell.phase(), Phase::Cleanup);
+
+        let mut mut_data_cleanup = cell.get_mut_unlocked().unwrap();
+        *Rc::get_mut(&mut mut_data_cleanup).unwrap() = String::from("final");
+        let _ = mut_data_cleanup;
+
+        let final_data = cell.get_mut_unlocked().unwrap();
+        assert_eq!(*Rc::get_mut(final_data).unwrap(), "final");
+        let _ = final_data;
+    }
+
+    #[test]
+    fn test_multi_threaded_with_sync_data() {
+        let cell_instance = PhasedCell::new(String::from("initial"));
+
+        cell_instance
+            .get_mut_unlocked()
+            .map(|s| *s = String::from("setup_value"))
+            .unwrap();
+        assert_eq!(*cell_instance.get_mut_unlocked().unwrap(), "setup_value");
+
+        let cell = Arc::new(cell_instance);
+
+        cell.transition_to_read(|s: &mut String| {
+            *s = String::from("read_value");
+            Ok::<(), std::io::Error>(())
+        })
+        .unwrap();
+
+        let handles: Vec<_> = (0..5)
+            .map(|_| {
+                let cell_clone: Arc<PhasedCell<String>> = Arc::clone(&cell);
+                thread::spawn(move || {
+                    let data = cell_clone.read().unwrap();
+                    assert_eq!(*data, "read_value");
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        cell.transition_to_cleanup(|s: &mut String| {
+            *s = String::from("cleanup_value");
+            Ok::<(), std::io::Error>(())
+        })
+        .unwrap();
+        assert_eq!(cell.phase(), Phase::Cleanup);
+
+        let cleanup_data = cell.get_mut_unlocked().unwrap();
+        *cleanup_data = String::from("final_value");
+        assert_eq!(*cleanup_data, "final_value");
+        let _ = cleanup_data;
+    }
+}
+
+#[cfg(feature = "setup_read_cleanup-graceful")]
+#[cfg(test)]
+mod tests_of_graceful_phased_cell {
+    use super::*;
+
+    #[test]
+    fn test_single_threaded_with_non_sync_data() {
+        let cell = GracefulPhasedCell::new(Rc::new(vec![10, 20]));
+
+        cell.get_mut_unlocked()
+            .map(|rc_vec| *Rc::get_mut(rc_vec).unwrap() = vec![1, 2, 3])
+            .unwrap();
+        assert_eq!(**cell.get_mut_unlocked().unwrap(), vec![1, 2, 3]);
+
+        cell.transition_to_read(|_v: &mut Rc<Vec<i32>>| Ok::<(), std::io::Error>(()))
+            .unwrap();
+
+        let data = cell.read().unwrap();
+        assert_eq!(**data, vec![1, 2, 3]);
+        cell.finish_reading();
+
+        cell.transition_to_cleanup(Duration::ZERO, |rc_vec: &mut Rc<Vec<i32>>| {
+            *Rc::get_mut(rc_vec).unwrap() = vec![4, 5, 6];
+            Ok::<(), std::io::Error>(())
+        })
+        .unwrap();
+        assert_eq!(cell.phase(), Phase::Cleanup);
+
+        let mut mut_data_cleanup = cell.get_mut_unlocked().unwrap();
+        *Rc::get_mut(&mut mut_data_cleanup).unwrap() = vec![7, 8, 9];
+        let _ = mut_data_cleanup;
+
+        let final_data = cell.get_mut_unlocked().unwrap();
+        assert_eq!(**Rc::get_mut(final_data).unwrap(), vec![7, 8, 9]);
+        let _ = final_data;
+    }
+
+    #[cfg(feature = "setup_read_cleanup-graceful")]
+    #[test]
+    fn test_multi_threaded_with_sync_data() {
+        let cell_instance = GracefulPhasedCell::new(String::from("initial graceful"));
+
+        cell_instance
+            .get_mut_unlocked()
+            .map(|s| *s = String::from("setup_graceful_value"))
+            .unwrap();
+        assert_eq!(
+            *cell_instance.get_mut_unlocked().unwrap(),
+            "setup_graceful_value"
+        );
+
+        let cell = Arc::new(cell_instance);
+
+        cell.transition_to_read(|s: &mut String| {
+            *s = String::from("read_graceful_value");
+            Ok::<(), std::io::Error>(())
+        })
+        .unwrap();
+
+        let handles: Vec<_> = (0..5)
+            .map(|_| {
+                let cell_clone: Arc<GracefulPhasedCell<String>> = Arc::clone(&cell);
+                thread::spawn(move || {
+                    let data = cell_clone.read().unwrap();
+                    assert_eq!(*data, "read_graceful_value");
+                    cell_clone.finish_reading();
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        cell.transition_to_cleanup(Duration::ZERO, |s: &mut String| {
+            *s = String::from("cleanup_graceful_value");
+            Ok::<(), std::io::Error>(())
+        })
+        .unwrap();
+        assert_eq!(cell.phase(), Phase::Cleanup);
+
+        let cleanup_data = cell.get_mut_unlocked().unwrap();
+        *cleanup_data = String::from("final_graceful_value");
+        assert_eq!(*cleanup_data, "final_graceful_value");
+        let _ = cleanup_data;
+    }
+}


### PR DESCRIPTION
Since `PhasedCell<T>` and `GracefulPhasedCell<T>` are also intended for single-threaded data access, `T` does not need to satisfy `Send + Sync` bounds by default. I have changed the implementation to apply these bounds conditionally, so they are only required when the cell itself is used in a multi-threaded context.